### PR TITLE
N5# Correção de variável que ocultava campo (shadowing) em NamedEntity

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
@@ -44,8 +44,8 @@ public class NamedEntity extends BaseEntity {
 
 	@Override
 	public String toString() {
-		String name = this.getName();
-		return (name != null) ? name : "<null>";
+		String value = this.getName();
+		return (value != null) ? value : "<null>";
 	}
 
 }


### PR DESCRIPTION
Renomeada variável local 'name' no método toString() para evitar shadowing do campo 'name'. Correção remove o warning do SonarQube (java:S1117).